### PR TITLE
Add many customizable params

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ If you are not satisfied with the result of AI translation，use [`overrides`](#
 | namespaceGlob    | string\|string[]                      | Glob for namespace(s) to process, useful to include or exclude some files, learn more [glob](https://www.npmjs.com/package/glob#usage)                                                            |    No    |
 | openAIApiUrl     | string                                | Optional base url of OpenAI API, useful with proxy                                              |    No    |
 | openAIApiUrlPath | string                                | Optional URL endpoint of OpenAI API, useful with proxy                                          |    No    |
+| modelContextLimit | number                               | Optional max context window that the model supports. For example for gpt-4-32k, the context is 32768 tokens. Default to 4096 (gpt-3.5-turbo)      |    No    |
+| modelContextSplit | number                               | Optional ratio to split between number of input / output tokens. For example, if the input language is English and output is Spanish, you may expect 1 input token to produce 2 output tokens. In this case, the variable is set to 1/2. By default, modelContextSplit is set to 1/1      |    No    |
+| systemPromptTemplate | function                               | (For advanced usage) Custom prompt template. See "translate.ts" for the default prompt.      |    No    |
+| additionalReqBodyParams | any                               | (For advanced usage) Custom parameters to be passed into request body. Useful if you use a self-hosted model and you want to customize model parameters. For example, see [llama.cpp server example](https://github.com/ggerganov/llama.cpp/tree/master/examples/server)      |    No    |
 |  |
 
 ## Contributing

--- a/packages/core/src/split.ts
+++ b/packages/core/src/split.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs'
 import { encode } from 'gpt-3-encoder'
 
-const MAX_TOKENS = 2000
 
-export function splitJSONtoSmallChunks(object: Record<string, unknown>) {
+export function splitJSONtoSmallChunks(object: Record<string, unknown>, options: { modelContextLimit: number, modelContextSplit: number }) {
+  const maxInputToken = Math.floor(options.modelContextLimit * options.modelContextSplit)
   const chunks: Record<string, unknown>[] = []
   const keys = Object.keys(object)
   const totalLength = keys.length
@@ -17,7 +17,7 @@ export function splitJSONtoSmallChunks(object: Record<string, unknown>) {
     const value = object[key]
     chunkSize += encode(key).length + 2 // "key":
     const nextValueSize = isPlainObject(value) ? getJSONTokenSize(value, 1) : getPrimitiveValueSize(value)
-    if (chunkSize + nextValueSize > MAX_TOKENS) {
+    if (chunkSize + nextValueSize > maxInputToken) {
       // clear temp chunk
       chunks.push({ ...tempChunk })
       tempChunk = {}

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -15,8 +15,9 @@ export class Task {
 
   async start(onProgress: (current: number, total: number) => any) {
     const { inputNSFilePath, namespace, locale } = this.work
+    const { modelContextLimit, modelContextSplit } = this.transmart.options
     const content = await readFile(inputNSFilePath, { encoding: 'utf-8' })
-    const chunks = splitJSONtoSmallChunks(JSON.parse(content))
+    const chunks = splitJSONtoSmallChunks(JSON.parse(content), { modelContextLimit, modelContextSplit })
     let count = 0
 
     const p = chunks.map((chunk, index) => {
@@ -49,7 +50,7 @@ export class Task {
   }
 
   private async run(content: string, index: number): Promise<TaskResult> {
-    const { openAIApiKey, openAIApiUrl, openAIApiUrlPath, openAIApiModel, context } = this.transmart.options
+    const { openAIApiKey, openAIApiUrl, openAIApiUrlPath, openAIApiModel, context, systemPromptTemplate, additionalReqBodyParams } = this.transmart.options
     const { locale } = this.work
 
     const data = await translate({
@@ -60,6 +61,8 @@ export class Task {
       openAIApiKey,
       openAIApiUrl,
       openAIApiUrlPath,
+      systemPromptTemplate,
+      additionalReqBodyParams,
     })
     return {
       content: data,

--- a/packages/core/src/translate.ts
+++ b/packages/core/src/translate.ts
@@ -3,16 +3,17 @@ import { getLanguageDisplayName } from './language'
 import { TranslateParams } from './types'
 
 export async function translate(params: TranslateParams) {
-  const { targetLang, openAIApiKey, openAIApiUrl, openAIApiUrlPath, content, openAIApiModel, context } = params
+  const { targetLang, openAIApiKey, openAIApiUrl, openAIApiUrlPath, content, openAIApiModel, context, systemPromptTemplate, additionalReqBodyParams } = params
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${openAIApiKey}`,
   }
   const languageName = getLanguageDisplayName(targetLang)
-  const systemPrompt =
-    `Translate the i18n JSON file to ${languageName} according to the BCP 47 standard` +
-    (context ? `\nHere are some contexts to help with better translation.  ---${context}---` : '') +
-    `\n Keep the keys the same as the original file and make sure the output remains a valid i18n JSON file.`
+  const systemPrompt = systemPromptTemplate
+    ? systemPromptTemplate({ languageName, context })
+    : `Translate the i18n JSON file to ${languageName} according to the BCP 47 standard` +
+      (context ? `\nHere are some contexts to help with better translation.  ---${context}---` : '') +
+      `\n Keep the keys the same as the original file and make sure the output remains a valid i18n JSON file.`
   const body = {
     model: openAIApiModel,
     temperature: 0,
@@ -23,6 +24,7 @@ export async function translate(params: TranslateParams) {
       },
       { role: 'user', content: `${content}` },
     ],
+    ...(additionalReqBodyParams || {}),
   }
   const finalUrlPath = openAIApiUrl + openAIApiUrlPath
   const res = await fetch(finalUrlPath, {
@@ -39,5 +41,12 @@ export async function translate(params: TranslateParams) {
     throw new Error('No result')
   }
   const targetTxt = choices[0].message.content.trim()
-  return targetTxt
+  return findValidJSONInsideBody(targetTxt)
+}
+
+// TODO @ngxson : Sometimes, even "smart" models like GPT-4 does not understand and add a text before / after JSON
+const findValidJSONInsideBody = (input: string): string => {
+  const firstBracket = input.indexOf('{')
+  const lastBracket = input.lastIndexOf('}') + 1
+  return input.substring(firstBracket, lastBracket)
 }

--- a/packages/core/src/transmart.ts
+++ b/packages/core/src/transmart.ts
@@ -10,6 +10,8 @@ const DEFAULT_PARAMS: Partial<TransmartOptions> = {
   openAIApiUrl: 'https://api.openai.com',
   openAIApiUrlPath: '/v1/chat/completions',
   openAIApiModel: 'gpt-3.5-turbo-16k-0613',
+  modelContextLimit: 4096,
+  modelContextSplit: 1/1,
 }
 
 export class Transmart {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -53,6 +53,31 @@ export interface TransmartOptions {
    * ```
    */
   overrides?: Record<string, Record<string, Record<string, any>>>
+  /**
+   * The max context window that the model supports. For example for gpt-4-32k, the context is 32768 tokens. Default to 4096 (gpt-3.5-turbo)
+   */
+  modelContextLimit?: number
+  /**
+   * The ratio to split between number of input / output tokens. For example, if the input language is English and output is Spanish, you may expect 1 input token to produce 2 output tokens. In this case, the variable is set to 1/2. By default, modelContextSplit is set to 1/1
+   */
+  modelContextSplit?: number
+  /**
+   * (For advanced usage) Custom prompt template. See "translate.ts" for the default prompt.
+   */
+  systemPromptTemplate?: (data: {
+    languageName: string | undefined,
+    context: string | undefined,
+  }) => string
+  /**
+   * (For advanced usage) Custom parameters to be passed into request body. Useful if you use a self-hosted model and you want to customize model parameters. For example llama.cpp:
+   * {
+   *   mirostat_eta: 0.8,
+   *   mirostat_tau: 0.9,
+   *   mirostat: 1,
+   *   grammar: [JSON grammar]
+   * }
+   */
+  additionalReqBodyParams?: any
 }
 
 export interface Stats {
@@ -75,6 +100,8 @@ export interface TranslateParams {
   openAIApiKey: string
   openAIApiUrl: string
   openAIApiUrlPath: string
+  systemPromptTemplate: TransmartOptions['systemPromptTemplate']
+  additionalReqBodyParams: any
 }
 
 export interface TranslateResult {


### PR DESCRIPTION
Added these customizable params (related to https://github.com/Quilljou/transmart/issues/4)

| Name             | Type                                  | Description                                                                                     | Required |
| ---------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- | :------: |
| modelContextLimit | number                               | Optional max context window that the model supports. For example for gpt-4-32k, the context is 32768 tokens. Default to 4096 (gpt-3.5-turbo)      |    No    |
| modelContextSplit | number                               | Optional ratio to split between number of input / output tokens. For example, if the input language is English and output is Spanish, you may expect 1 input token to produce 2 output tokens. In this case, the variable is set to 1/2. By default, modelContextSplit is set to 1/1      |    No    |
| systemPromptTemplate | function                               | (For advanced usage) Custom prompt template. See "translate.ts" for the default prompt.      |    No    |
| additionalReqBodyParams | any                               | (For advanced usage) Custom parameters to be passed into request body. Useful if you use a self-hosted model and you want to customize model parameters. For example, see [llama.cpp server example](https://github.com/ggerganov/llama.cpp/tree/master/examples/server)      |    No    |

Also added a function to filter out the JSON inside the response text (when using GPT-4-preview - the one with 128k context, sometimes the model add some texts before/after the JSON)

```ts
const findValidJSONInsideBody = (input: string): string => {
  const firstBracket = input.indexOf('{')
  const lastBracket = input.lastIndexOf('}') + 1
  return input.substring(firstBracket, lastBracket)
}
```