### PR TITLE
Add support for cache and retry

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "registry": "https://registry.npmjs.org/"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,11 +20,7 @@
     "build:watch": "npm run clean && tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
-<<<<<<< HEAD
     "@transmart/core": "^0.4.0",
-=======
-    "@transmart/core": "^0.3.1",
->>>>>>> e69981e3abf4c44012faa80e443bde904c1b866d
     "@types/spinnies": "^0.5.0",
     "commander": "^9.4.1",
     "cosmiconfig": "^8.3.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmart/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
@@ -20,7 +20,7 @@
     "build:watch": "npm run clean && tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
-    "@transmart/core": "^0.3.0",
+    "@transmart/core": "^0.4.0",
     "@types/spinnies": "^0.5.0",
     "commander": "^9.4.1",
     "cosmiconfig": "^8.3.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmart/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/packages/core/src/split.ts
+++ b/packages/core/src/split.ts
@@ -1,8 +1,9 @@
-import * as fs from 'fs'
 import { encode } from 'gpt-3-encoder'
 
-
-export function splitJSONtoSmallChunks(object: Record<string, unknown>, options: { modelContextLimit: number, modelContextSplit: number }) {
+export function splitJSONtoSmallChunks(
+  object: Record<string, unknown>,
+  options: { modelContextLimit: number; modelContextSplit: number },
+) {
   const maxInputToken = Math.floor(options.modelContextLimit * options.modelContextSplit)
   const chunks: Record<string, unknown>[] = []
   const keys = Object.keys(object)

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -1,5 +1,5 @@
 import { Transmart } from './transmart'
-import { RunWork, TranslateResult } from './types'
+import { RunWork } from './types'
 import { readFile } from 'node:fs/promises'
 import { translate } from './translate'
 import { isPlainObject, splitJSONtoSmallChunks } from './split'
@@ -50,7 +50,16 @@ export class Task {
   }
 
   private async run(content: string, index: number): Promise<TaskResult> {
-    const { openAIApiKey, openAIApiUrl, openAIApiUrlPath, openAIApiModel, baseLocale, context, systemPromptTemplate, additionalReqBodyParams } = this.transmart.options
+    const {
+      openAIApiKey,
+      openAIApiUrl,
+      openAIApiUrlPath,
+      openAIApiModel,
+      baseLocale,
+      context,
+      systemPromptTemplate,
+      additionalReqBodyParams,
+    } = this.transmart.options
     const { locale } = this.work
 
     const data = await translate({

--- a/packages/core/src/translate.ts
+++ b/packages/core/src/translate.ts
@@ -62,7 +62,6 @@ export async function translate(params: TranslateParams, retryTime = 0): Promise
     throw new Error('No result')
   }
   const targetTxt = choices[0].message.content.trim()
-  console.log('targetTxt', targetTxt)
   return findValidJSONInsideBody(targetTxt)
 }
 

--- a/packages/core/src/transmart.ts
+++ b/packages/core/src/transmart.ts
@@ -42,7 +42,7 @@ export class Transmart {
           const targetCachePath = path.join(cachePath, pairHash)
           // check if the cache file exists
           if (existsSync(targetCachePath) && existsSync(outputNSFilePath)) {
-            console.log(`cache file and output file exists, skip for namespace ${ns} and locale ${targetLocale}`)
+            console.log(`cache file and output file exists, skip for namespace ${ns} - locale ${targetLocale}`)
             return
           }
         }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,14 @@ export interface TransmartOptions {
    */
   localePath: string
   /**
+   * where the cache files are stored, there will be some cache files generated during the translation process
+   */
+  cachePath?: string
+  /**
+   * whether to enable cache, default to false
+   */
+  cacheEnabled?: boolean
+  /**
    * the OpenAI API Key. For instructions on how to obtain a key, please refer to: https://gptforwork.com/setup/how-to-create-openai-api-key
    */
   openAIApiKey: string
@@ -28,6 +36,10 @@ export interface TransmartOptions {
    * Provide some context for a more accurate translation.
    */
   context?: string
+  /**
+   * Retry times when the translation fails, default to 3
+   */
+  retryTimes?: number
   /**
    * OpenAI API model, default to `gpt-3.5-turbo`
    */
@@ -64,10 +76,7 @@ export interface TransmartOptions {
   /**
    * (For advanced usage) Custom prompt template. See "translate.ts" for the default prompt.
    */
-  systemPromptTemplate?: (data: {
-    languageName: string | undefined,
-    context: string | undefined,
-  }) => string
+  systemPromptTemplate?: (data: { languageName: string | undefined; context: string | undefined }) => string
   /**
    * (For advanced usage) Custom parameters to be passed into request body. Useful if you use a self-hosted model and you want to customize model parameters. For example llama.cpp:
    * {
@@ -97,6 +106,7 @@ export interface TranslateParams {
   baseLang: string
   targetLang: string
   context?: string
+  retryTimes?: number
   openAIApiModel: string
   openAIApiKey: string
   openAIApiUrl: string
@@ -126,4 +136,5 @@ export interface RunWork {
   locale: string
   inputNSFilePath: string
   outputNSFilePath: string
+  cachePath: string
 }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+/**
+ * A function that returns a hash of the input data and output file paths
+ * If any of the input data or output file paths change, the hash will change
+ * @param inputNSFilePath
+ * @param outputNSFilePath
+ * @returns
+ */
+export const getPairHash = (inputNSFilePath: string, outputNSFilePath: string): string => {
+  const data = readFileSync(inputNSFilePath, { encoding: 'utf-8' })
+  const hash = createHash('sha1')
+  hash.update(data)
+  hash.update(outputNSFilePath)
+  return hash.digest('hex')
+}


### PR DESCRIPTION
Thanks so much for building such a helpful project, it powers my project greatly!

During my usage, I find some issues:

* Every time run `translate`, it will translate all files even the original files is not changed at all, so need some cache mechanism to avoid extra uncessary translations. 
* For large files, if one of the chunk is translated failed based on OpenAI (API call is failed due to some reasons), the whole translate result will fail, so need to add retry support to enhance the sccess rate of the whole file.

For resolving above problems:
* I added support cache support: Introduce a new `.cache` folder to store the hash of `original file` and `target file`, if original file is changed or target file path is changed or taget file removed, the translation process will proceed, otherwise skip.
* Add `retryTimes` for API call, if API fails to repsond, it will retry up to 3 times by default.

Above also exposed to the params, and easy to override.