### PR TITLE
Fix JSON parse error for unpected cases

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "glob": "^9.3.0",
     "gpt-3-encoder": "^1.1.4",
     "gpt3-tokenizer": "^1.1.5",
+    "jsonrepair": "^3.6.0",
     "node-fetch": "^2.6.9",
     "p-limit": "^3.1.0"
   },


### PR DESCRIPTION
Issue:
For some cases, LLM will not output the correct json, for example, it may lack the final `}` in output, or output unexpected characters, this will cause the final `pack` function fail, because the `next.content` cannot be JSON parsed correctly. So the  whole translation of the large file will fail.

Fix:
In order to fix this, I introduced a new package `jsonrepair`, used for fixing the unexpected json string. Based on this, the translation success rate is highly imroved! 

