### PR TITLE
fix: change to use relative path for hash

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
+import * as path from 'path'
 
 /**
  * A function that returns a hash of the input data and output file paths
@@ -12,6 +13,6 @@ export const getPairHash = (inputNSFilePath: string, outputNSFilePath: string): 
   const data = readFileSync(inputNSFilePath, { encoding: 'utf-8' })
   const hash = createHash('sha1')
   hash.update(data)
-  hash.update(outputNSFilePath)
+  hash.update(path.relative(process.cwd(), outputNSFilePath))
   return hash.digest('hex')
 }


### PR DESCRIPTION
fix: change to use relative path for hash.

Previously, we use absolute path to make the hash. But if the project is used across different PC, the root path for the project is different, so the hash will be different, so will cause translation fully triggerred instead of skipped.

So here change to use relative path for hash.